### PR TITLE
fix: deck widget native image drag bug and add cross-page drag support

### DIFF
--- a/server/components/DeckPanel/DeckPanel.css
+++ b/server/components/DeckPanel/DeckPanel.css
@@ -536,7 +536,7 @@ body.perf-mode .deck-key .deck-key-anim { opacity: 0; }
   transition: transform .12s ease, filter .12s ease;
 }
 .deck-arrow:hover:not([disabled]) { filter: brightness(1.25); color: var(--text, #e7e9ee); }
-.deck-arrow:active:not([disabled]) { transform: translateY(1px); }
+.deck-arrow:active:not([disabled]), .deck-arrow.is-drop:not([disabled]) { transform: translateY(1px); background: rgba(255, 255, 255, 0.15); border-radius: 4px; }
 .deck-arrow[disabled] { opacity: .3; cursor: default; }
 .deck-dots { display: flex; gap: 6px; align-items: center; }
 .deck-dots i {

--- a/server/js/deck-model.js
+++ b/server/js/deck-model.js
@@ -801,6 +801,36 @@ function swapKeysAt(config, nav, indexA, indexB) {
   return normalizeDeckConfig(cfg);
 }
 
+// Move a key from its current slot to the first available slot on a target page.
+// Used for drag-and-dropping across pages. Returns a NEW normalized config.
+function moveKeyToPage(config, nav, sourceIndex, targetPageIndex) {
+  const cfg = cloneConfig(normalizeDeckConfig(config));
+  const folder = folderAtPath(cfg, (nav && nav.profileId) || cfg.activeProfile, nav && nav.path);
+  const sourcePageIndex = clampInt(nav && nav.pageIndex, 0, folder.pages.length - 1, 0);
+  
+  if (sourcePageIndex === targetPageIndex || targetPageIndex < 0 || targetPageIndex >= folder.pages.length) {
+    return normalizeDeckConfig(cfg);
+  }
+  
+  const sourceKeys = folder.pages[sourcePageIndex].keys;
+  const targetKeys = folder.pages[targetPageIndex].keys;
+  
+  if (sourceIndex >= 0 && sourceIndex < sourceKeys.length && sourceKeys[sourceIndex]) {
+    // Find first empty slot on target page
+    let emptySlot = targetKeys.findIndex(k => k === null);
+    if (emptySlot === -1) {
+      // If full, expand the target page
+      emptySlot = targetKeys.length;
+      targetKeys.push(null);
+    }
+    
+    // Move key
+    targetKeys[emptySlot] = sourceKeys[sourceIndex];
+    sourceKeys[sourceIndex] = null;
+  }
+  return normalizeDeckConfig(cfg);
+}
+
 // Append an empty page to the resolved folder, sized to the OWNING profile's
 // grid. Returns a NEW normalized config.
 function addPageAt(config, nav) {
@@ -1066,7 +1096,7 @@ function evaluateKeyState(state, snapshot) {
   }
 }
 
-const DECK_MODEL_API = { normalizeDeckConfig, normalizeDeckWellImage, normalizeDeckMediaStyle, normalizeDeckLook, effectiveDeckLook, setProfileLook, resolveView, setKeyAt, addPageAt, removePageAt, newKeyId, newProfileId, setActiveProfile, addProfile, renameProfile, removeProfile, getProfile, addProfileFromTemplate, cloneConfig, evaluateKeyState, gridForSize, gridOf, reshapeDeckConfig, fitDeckGrids, foldDeckGrids, swapKeysAt, keyStyleOf, applyStyleToPage, KEY_STYLE_FIELDS, KEY_SIZES, KEY_GAPS, DECK_STATE_SOURCES, DECK_LIVE_SOURCES, DECK_SENSOR_METRICS, SLIDER_TARGETS, formatLiveValue, timersByLabel, sensorsFromSystem, batteriesByName, DECK_MIN, DECK_MAX, PRESS_FX, ICON_FITS, GRAD_DIRS, LABEL_POSITIONS, STYLE_SIZES, KEY_ANIMS, CAP_STYLES, KEY_SHAPES, PLATE_STYLES };
+const DECK_MODEL_API = { normalizeDeckConfig, normalizeDeckWellImage, normalizeDeckMediaStyle, normalizeDeckLook, effectiveDeckLook, setProfileLook, resolveView, setKeyAt, addPageAt, removePageAt, newKeyId, newProfileId, setActiveProfile, addProfile, renameProfile, removeProfile, getProfile, addProfileFromTemplate, cloneConfig, evaluateKeyState, gridForSize, gridOf, reshapeDeckConfig, fitDeckGrids, foldDeckGrids, swapKeysAt, moveKeyToPage, keyStyleOf, applyStyleToPage, KEY_STYLE_FIELDS, KEY_SIZES, KEY_GAPS, DECK_STATE_SOURCES, DECK_LIVE_SOURCES, DECK_SENSOR_METRICS, SLIDER_TARGETS, formatLiveValue, timersByLabel, sensorsFromSystem, batteriesByName, DECK_MIN, DECK_MAX, PRESS_FX, ICON_FITS, GRAD_DIRS, LABEL_POSITIONS, STYLE_SIZES, KEY_ANIMS, CAP_STYLES, KEY_SHAPES, PLATE_STYLES };
 if (typeof window !== 'undefined') {
   window.DeckModel = DECK_MODEL_API;
 }

--- a/server/js/deck.js
+++ b/server/js/deck.js
@@ -1051,6 +1051,7 @@
   // tap to open the editor. A small movement threshold separates a tap from a drag.
   function bindEditKey(tile, instanceId, navCtx, slotIndex, key, node) {
     bindPressFeedback(node);
+    node.ondragstart = (e) => e.preventDefault(); // Stop native HTML5 drag of images
 
     // Quick-delete badge (top-left). Its own pointerdown is swallowed so it never
     // starts a drag or the cap's press depression.
@@ -1101,7 +1102,6 @@
       clone.style.borderRadius = getComputedStyle(node).borderRadius;
       Object.assign(clone.style, { position: 'fixed', left: (r.left / z) + 'px', top: (r.top / z) + 'px', width: (r.width / z) + 'px', height: (r.height / z) + 'px', margin: '0' });
       document.body.appendChild(clone);
-      try { node.setPointerCapture(e.pointerId); } catch { /* capture unsupported */ }
     };
     const moveClone = (e) => {
       const z = zoom();
@@ -1109,7 +1109,12 @@
       clone.style.top = ((e.clientY - oy) / z) + 'px';
       clearDrop();
       const tgt = slotUnder(e.clientX, e.clientY);
-      if (tgt && tgt !== node) tgt.classList.add('is-drop');
+      if (tgt && tgt !== node) {
+        tgt.classList.add('is-drop');
+      } else {
+        const pager = document.elementsFromPoint(e.clientX, e.clientY).find(el => el.classList && (el.classList.contains('deck-prev') || el.classList.contains('deck-next')));
+        if (pager && !pager.disabled) pager.classList.add('is-drop');
+      }
     };
     const endDrag = (e) => {
       if (clone) { clone.remove(); clone = null; }
@@ -1118,9 +1123,20 @@
       if (!dragging) return;
       dragging = false;
       const tgt = slotUnder(e.clientX, e.clientY);
-      const to = tgt ? parseInt(tgt.dataset.slot, 10) : NaN;
-      if (Number.isInteger(to) && to !== slotIndex) {
-        saveConfig(instanceId, window.DeckModel.swapKeysAt(getConfig(instanceId), navCtx, slotIndex, to));
+      const pager = document.elementsFromPoint(e.clientX, e.clientY).find(el => el.classList && (el.classList.contains('deck-prev') || el.classList.contains('deck-next')));
+      
+      if (pager && !pager.disabled && window.DeckModel.moveKeyToPage) {
+        const dir = pager.classList.contains('deck-prev') ? -1 : 1;
+        const targetPage = navCtx.pageIndex + dir;
+        saveConfig(instanceId, window.DeckModel.moveKeyToPage(getConfig(instanceId), navCtx, slotIndex, targetPage));
+        // Switch view to the target page to show the dropped item
+        const st = navOf(instanceId);
+        st.pageIndex = targetPage;
+      } else {
+        const to = tgt ? parseInt(tgt.dataset.slot, 10) : NaN;
+        if (Number.isInteger(to) && to !== slotIndex) {
+          saveConfig(instanceId, window.DeckModel.swapKeysAt(getConfig(instanceId), navCtx, slotIndex, to));
+        }
       }
       render(tile, instanceId);   // rebuild (also clears any transient drag state)
     };
@@ -1128,6 +1144,7 @@
     node.addEventListener('pointerdown', (e) => {
       if (e.button != null && e.button > 0) return;
       pid = e.pointerId; downX = e.clientX; downY = e.clientY; moved = false;
+      try { node.setPointerCapture(e.pointerId); } catch { /* capture unsupported */ }
     });
     node.addEventListener('pointermove', (e) => {
       if (pid == null || e.pointerId !== pid) return;
@@ -1208,6 +1225,7 @@
         if (key.bgImage.blur) { btn.classList.add('has-bgblur'); btn.style.setProperty('--key-blur', key.bgImage.blur + 'px'); }
         const wrap = el('div', 'deck-key-bgimg');
         const bgImg = document.createElement('img');
+        bgImg.draggable = false;
         bgImg.src = bgSrc; bgImg.alt = '';
         wrap.appendChild(bgImg);
         btn.appendChild(wrap);
@@ -1228,6 +1246,7 @@
       ? window.DeckIcons.el(key.icon.value) : null;
     if (iconSrc) {
       const img = document.createElement('img');
+      img.draggable = false;
       img.src = iconSrc; img.alt = '';
       ico.appendChild(img);
       // Image fit: 'cover' = full-bleed (label gets a readable scrim), 'contain' =
@@ -2176,12 +2195,12 @@
     // Footer: arrows + page dots (only when more than one page, or in edit mode)
     if (view.pageCount > 1 || state.editing) {
       const foot = el('div', 'deck-foot');
-      const prev = el('button', 'deck-arrow', '‹'); prev.type = 'button';
+      const prev = el('button', 'deck-arrow deck-prev', '‹'); prev.type = 'button';
       prev.disabled = view.pageIndex === 0;
       prev.addEventListener('click', () => { state.pageIndex = Math.max(0, view.pageIndex - 1); render(tile, instanceId); });
       const dots = el('div', 'deck-dots');
       for (let i = 0; i < view.pageCount; i++) { const d = el('i'); if (i === view.pageIndex) d.classList.add('active'); dots.appendChild(d); }
-      const next = el('button', 'deck-arrow', '›'); next.type = 'button';
+      const next = el('button', 'deck-arrow deck-next', '›'); next.type = 'button';
       next.disabled = view.pageIndex >= view.pageCount - 1;
       next.addEventListener('click', () => { state.pageIndex = Math.min(view.pageCount - 1, view.pageIndex + 1); render(tile, instanceId); });
       foot.appendChild(prev); foot.appendChild(dots); foot.appendChild(next);


### PR DESCRIPTION
This addresses several UX issues with the Deck widget's drag-and-drop reordering logic.

- **Native Image Drag Interception:** Custom launch/script icons (rendered as `<img>` tags) were triggering the browser's native drag behavior, which swallowed pointer events. Added `draggable="false"` and `ondragstart` prevention.
- **Pointer Focus Loss:** Switched the drag initiation to capture the pointer immediately on `pointerdown` via `setPointerCapture(e.pointerId)`. This prevents dragged buttons from getting stuck or dropped if the cursor leaves the element bounds abruptly during fast movements.
- **Cross-Page Dragging:** Keys can now be dragged onto the pagination arrows (`.deck-prev` / `.deck-next`) to turn pages mid-drag. Added `moveKeyToPage` in `deck-model.js` to handle safely transferring keys into the first available slot on the target page.
